### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ In our projects, we format the errors like that:
 
 If we raise a `ValidationError`, then field is optional.
 
-In order to acheive that, we implement a custom exception handler:
+In order to achieve that, we implement a custom exception handler:
 
 ```python
 from rest_framework.views import exception_handler


### PR DESCRIPTION
Hi! :wave: 

I have found a typo: acheive should be achieve.

Thought I'd spare some time and create this PR to fix that :slightly_smiling_face: 