### PR TITLE
Do not use both `blank=True` & `null=True` when unnecessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ class Course(models.Model):
     slug_url = models.SlugField(unique=True)
 
     repository = models.URLField(blank=True)
-    video_channel = models.URLField(blank=True, null=True)
-    facebook_group = models.URLField(blank=True, null=True)
+    video_channel = models.URLField(blank=True)
+    facebook_group = models.URLField(blank=True)
 
-    logo = models.ImageField(blank=True, null=True)
+    logo = models.ImageField(blank=True)
 
     public = models.BooleanField(default=True)
 


### PR DESCRIPTION
According to [the Django documentation](https://docs.djangoproject.com/en/3.1/ref/models/fields/#django.db.models.Field.null), setting both `blank=True` & `null=True` on `CharField` and its derived classes is considered a bad practice:

> Avoid using null on string-based fields such as CharField and TextField. If a string-based field has null=True, that means it has two possible values for “no data”: NULL, and the empty string. In most cases, it’s redundant to have two possible values for “no data;” the Django convention is to use the empty string, not NULL. One exception is when a CharField has both unique=True and blank=True set. In this situation, null=True is required to avoid unique constraint violations when saving multiple objects with blank values.

![](https://i.stack.imgur.com/TMMej.png)
![](https://i.stack.imgur.com/gUanA.png)

In our current projects, we're using these terms correctly, but the snippet in the guide is not following the guidelines.

Closes #49 