### PR TITLE
Minor typo fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ We are defining the model's `clean` method, because we want to make sure we get 
 
 Now, in order for the `clean` method to be called, someone must call `full_clean` on an instance of our model, before saving.
 
-**Our recommendation is to do that in the service, right before calling clean:**
+**Our recommendation is to do that in the service, right before calling save:**
 
 ```python
 def course_create(*, name: str, start_date: date, end_date: date) -> Course:


### PR DESCRIPTION
Fixes a minor mistake in README.

In the example, it should refer to `save` method in the snippet below, rather than a `clean` one.