### PR TITLE
change-update-view-to-use-put-http-method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,7 +1218,7 @@ class CourseUpdateApi(SomeAuthenticationMixin, APIView):
         start_date = serializers.DateField(required=False)
         end_date = serializers.DateField(required=False)
 
-    def post(self, request, course_id):
+    def put(self, request, course_id):
         serializer = self.InputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 


### PR DESCRIPTION
Since the update view is altering the state of an object in the database, shouldn't we use `put` method as opposed to `post` ? . Please review this change.